### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow that is manually triggered
 
 name: Manual workflow
+permissions:
+  contents: read
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.


### PR DESCRIPTION
Potential fix for [https://github.com/Glowing-Games/glowing-games.github.io/security/code-scanning/1](https://github.com/Glowing-Games/glowing-games.github.io/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only echoes a greeting and does not require access to repository contents or other resources, we will set `contents: read` as the minimal permission. This ensures that the workflow has the least privileges necessary to execute.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
